### PR TITLE
translate: fix fs name and path generation

### DIFF
--- a/translate/v24tov31/v24tov31.go
+++ b/translate/v24tov31/v24tov31.go
@@ -17,7 +17,6 @@ package v24tov31
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"path"
 	"reflect"
 
@@ -49,24 +48,12 @@ func Check2_4(cfg old.Config, fsMap map[string]string) error {
 	}
 	fsMap["root"] = "/"
 	for _, fs := range cfg.Storage.Filesystems {
-		if len(fs.Name) == 0 {
-			f, err := ioutil.TempFile("", "ignition-fs-*")
-			if err != nil {
-				return fmt.Errorf("creating tmp fs file name: %w", err)
-			}
-
-			fs.Name = f.Name()
+		name, err := util.FSGeneration(fs.Name, fsMap)
+		if err != nil {
+			return fmt.Errorf("generating filesystem path and name: %w", err)
 		}
 
-		if _, ok := fsMap[fs.Name]; !ok {
-			// generate a random path
-			p, err := ioutil.TempDir("", fs.Name)
-			if err != nil {
-				return fmt.Errorf("creating tmp fs directory: %w", err)
-			}
-
-			fsMap[fs.Name] = p
-		}
+		fs.Name = name
 
 		if fs.Mount.Create != nil && !fs.Mount.Create.Force {
 			return fmt.Errorf("Config must force filesystem creation in case `mount.create` object is defined.")

--- a/translate_test.go
+++ b/translate_test.go
@@ -2508,6 +2508,38 @@ type input2_4 struct {
 	fsMap map[string]string
 }
 
+func TestCheck2_4WithGeneratedFSMap(t *testing.T) {
+	// in this config, Filesystem Name is not passed
+	// to verify the FS generation mechanism.
+	cfg := types2_4.Config{
+		Ignition: types2_4.Ignition{
+			Version: "2.4.0",
+		},
+		Storage: types2_4.Storage{
+			Filesystems: []types2_4.Filesystem{
+				{
+					Mount: &types2_4.Mount{
+						Device: "/dev/disk/by-partlabel/var",
+						Format: "xfs",
+						Create: &types2_4.Create{
+							Force: true,
+						},
+					},
+				},
+			},
+		},
+	}
+	fsMap := make(map[string]string)
+
+	if err := v24tov31.Check2_4(cfg, fsMap); err != nil {
+		t.Errorf("error should be nil got: %v", err)
+	}
+
+	if len(fsMap) != 2 {
+		t.Errorf("fsMap should have 2 keys: 'root' and a generated one. Got: %d", len(fsMap))
+	}
+}
+
 func TestCheck2_4(t *testing.T) {
 	goodConfigs := []input2_4{
 		{

--- a/util/util.go
+++ b/util/util.go
@@ -18,8 +18,10 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
+	"math/rand"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // Error definitions
@@ -140,12 +142,9 @@ func IntV(in *int) int {
 // FSMap is required to link the filesystem from v2 to v3 with the rest of the configuration.
 func FSGeneration(name string, fsMap map[string]string) (string, error) {
 	if len(name) == 0 {
-		f, err := ioutil.TempFile("", "ignition-fs-*")
-		if err != nil {
-			return "", fmt.Errorf("creating tmp fs file name: %w", err)
-		}
-
-		name = filepath.Base(f.Name())
+		rand.Seed(time.Now().Unix())
+		generatedName := rand.Int()
+		name = "ignition" + strconv.Itoa(generatedName)
 	}
 
 	if _, ok := fsMap[name]; !ok {

--- a/util/util.go
+++ b/util/util.go
@@ -17,6 +17,8 @@ package util
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
 	"strings"
 )
 
@@ -131,4 +133,30 @@ func IntV(in *int) int {
 		return 0
 	}
 	return *in
+}
+
+// FSGeneration generates a name and a path that will be used to feed
+// the `fsMap` in case consumer provided no entry for it in the map.
+// FSMap is required to link the filesystem from v2 to v3 with the rest of the configuration.
+func FSGeneration(name string, fsMap map[string]string) (string, error) {
+	if len(name) == 0 {
+		f, err := ioutil.TempFile("", "ignition-fs-*")
+		if err != nil {
+			return "", fmt.Errorf("creating tmp fs file name: %w", err)
+		}
+
+		name = filepath.Base(f.Name())
+	}
+
+	if _, ok := fsMap[name]; !ok {
+		// generate a random path
+		p, err := ioutil.TempDir("", name+"-*")
+		if err != nil {
+			return "", fmt.Errorf("creating tmp fs directory: %w", err)
+		}
+
+		fsMap[name] = p
+	}
+
+	return name, nil
 }


### PR DESCRIPTION
In this PR we fix the FS path generation. Initially we were relying on `fs.Name()` to generate a `TempDir` - but the `fs,Name()` is actually a path so `TempDir` can't use a path as a pattern otherwise it fails with:
> mkdirtemp /tmp/ignition-fs-1168358910: pattern contains path separator