### PR TITLE
Special handling for OEM partition

### DIFF
--- a/translate/v23tov30/v23tov30.go
+++ b/translate/v23tov30/v23tov30.go
@@ -404,9 +404,14 @@ func translateFilesystems(fss []old.Filesystem, m map[string]string) (ret []type
 			}
 		}
 
+		format := f.Mount.Format
+		if f.Name == "oem" && (wipe == nil || !*wipe) {
+			format = "btrfs"
+		}
+
 		ret = append(ret, types.Filesystem{
 			Device:         f.Mount.Device,
-			Format:         util.StrP(f.Mount.Format),
+			Format:         util.StrP(format),
 			WipeFilesystem: wipe,
 			Label:          f.Mount.Label,
 			UUID:           f.Mount.UUID,

--- a/translate/v24tov31/v24tov31.go
+++ b/translate/v24tov31/v24tov31.go
@@ -430,9 +430,14 @@ func translateFilesystems(fss []old.Filesystem, m map[string]string) (ret []type
 			}
 		}
 
+		format := f.Mount.Format
+		if f.Name == "oem" && (wipe == nil || !*wipe) {
+			format = "btrfs"
+		}
+
 		ret = append(ret, types.Filesystem{
 			Device:         f.Mount.Device,
-			Format:         util.StrP(f.Mount.Format),
+			Format:         util.StrP(format),
 			WipeFilesystem: wipe,
 			Label:          f.Mount.Label,
 			UUID:           f.Mount.UUID,

--- a/translate_test.go
+++ b/translate_test.go
@@ -127,6 +127,16 @@ var (
 						Options:        []types2_3.MountOption{"rw"},
 					},
 				},
+				{
+					Name: "oem",
+					Mount: &types2_3.Mount{
+						Device:  "/dev/disk/by-partlabel/OEM",
+						Format:  "ext4",
+						Label:   util.StrP("OEM"),
+						UUID:    &aUUID,
+						Options: []types2_3.MountOption{"r"},
+					},
+				},
 			},
 			Files: []types2_3.File{
 				{
@@ -878,6 +888,14 @@ var (
 					Label:          util.StrP("var"),
 					UUID:           &aUUID,
 					Options:        []types3_0.FilesystemOption{"rw"},
+				},
+				{
+					Path:    util.StrP("/usr/share/oem"),
+					Device:  "/dev/disk/by-partlabel/OEM",
+					Format:  util.StrP("btrfs"),
+					Label:   util.StrP("OEM"),
+					UUID:    &aUUID,
+					Options: []types3_0.FilesystemOption{"r"},
 				},
 			},
 			Files: []types3_0.File{

--- a/util/util.go
+++ b/util/util.go
@@ -153,8 +153,12 @@ func FSGeneration(name string, fsMap map[string]string) (string, error) {
 
 	if _, ok := fsMap[name]; !ok {
 		addedSuffixCounter += 1
-		// generate a new path
-		fsMap[name] = "/tmp/" + name + "-ign" + strconv.FormatUint(addedSuffixCounter, 10)
+		if name == "oem" {
+			fsMap[name] = "/usr/share/oem"
+		} else {
+			// generate a new path
+			fsMap[name] = "/tmp/" + name + "-ign" + strconv.FormatUint(addedSuffixCounter, 10)
+		}
 	}
 
 	counterMutex.Unlock()


### PR DESCRIPTION
- Use standard mount path for OEM partition
    
    Since the OEM partition is going to be mounted under /usr and already
    has a folder existing there, we don't need to come up with a random
    path and create a folder from it.
- Force filesystem format for OEM partition to be btrfs
    
    In Flatcar's Ignition branch there was a function to try all supported
    filesystem in case the user passed ext4 for the OEM partition while it
    is using btrfs. Since the OEM partition is going to be reused as is,
    we should handle the wrong format gracefully instead of failing now
    because the upstream Ignition version doesn't have this fallback logic.
    Silently enforce that the format of the OEM partition is btrfs so that
    even if the user has an outdated config that uses ext4, it works.



## How to use



## Testing done

[Ongoing](http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/4964/cldsv/)