### PR TITLE
util/util: make CheckPathUsesLink check for shared path

### DIFF
--- a/translate_test.go
+++ b/translate_test.go
@@ -172,6 +172,12 @@ var (
 						Mode: util.IntP(420),
 					},
 				},
+				{
+					Node: types2_3.Node{
+						Filesystem: "root",
+						Path:       "/testdir/helloworld",
+					},
+				},
 			},
 			Directories: []types2_3.Directory{
 				{
@@ -207,6 +213,15 @@ var (
 					LinkEmbedded1: types2_3.LinkEmbedded1{
 						Hard:   false,
 						Target: "/foobar",
+					},
+				},
+				{
+					Node: types2_3.Node{
+						Filesystem: "root",
+						Path:       "/testdir/hello",
+					},
+					LinkEmbedded1: types2_3.LinkEmbedded1{
+						Target: "/testdir/helloworld",
 					},
 				},
 			},
@@ -935,6 +950,17 @@ var (
 						},
 					},
 				},
+				{
+					Node: types3_0.Node{
+						Path:      "/testdir/helloworld",
+						Overwrite: util.BoolPStrict(true),
+					},
+					FileEmbedded1: types3_0.FileEmbedded1{
+						Contents: types3_0.FileContents{
+							Source: util.StrPStrict(""),
+						},
+					},
+				},
 			},
 			Directories: []types3_0.Directory{
 				{
@@ -968,6 +994,14 @@ var (
 					LinkEmbedded1: types3_0.LinkEmbedded1{
 						Hard:   util.BoolP(false),
 						Target: "/foobar",
+					},
+				},
+				{
+					Node: types3_0.Node{
+						Path: "/testdir/hello",
+					},
+					LinkEmbedded1: types3_0.LinkEmbedded1{
+						Target: "/testdir/helloworld",
 					},
 				},
 			},

--- a/util/util.go
+++ b/util/util.go
@@ -78,7 +78,11 @@ func (e DuplicateDropinError) Error() string {
 
 func CheckPathUsesLink(links []string, path string) string {
 	for _, l := range links {
-		if strings.HasPrefix(path, l) && path != l {
+		linkdir := l
+		if !strings.HasSuffix(l, "/") {
+			linkdir += "/"
+		}
+		if strings.HasPrefix(path, linkdir) && path != l {
 			return l
 		}
 	}


### PR DESCRIPTION
The CheckPathUsesLink check was looking for any prefix but should match
on the directory boundary so that using /mydir/mypath is only forbidden
if /mydir is a symlink and not if /my is a symlink.

Fixes https://github.com/flatcar-linux/Flatcar/issues/666

## How to use
Test that this works
```
storage:
  files:
    - path: /helloworld
  links:
    - path: /hello
      target: /helloworld
```

## Testing done
