### PR TITLE
translate: convert deprecated `networkd` to `files`

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,5 +28,5 @@ jobs:
     - name: Run linter
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.42.0
+        version: v1.42.1
         args: -E=gofmt --timeout=30m0s

--- a/translate/v23tov30/v23tov30.go
+++ b/translate/v23tov30/v23tov30.go
@@ -17,7 +17,9 @@ package v23tov30
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"path"
+	"path/filepath"
 	"reflect"
 
 	old "github.com/flatcar-linux/ignition/config/v2_3/types"
@@ -36,10 +38,6 @@ func Check2_3(cfg old.Config, fsMap map[string]string) error {
 	if rpt.IsFatal() || rpt.IsDeprecated() {
 		// disallow any deprecated fields
 		return fmt.Errorf("Invalid input config:\n%s", rpt.String())
-	}
-
-	if len(cfg.Networkd.Units) != 0 {
-		return util.UsesNetworkdError
 	}
 
 	// check that all filesystems have a path
@@ -138,6 +136,10 @@ func Translate(cfg old.Config, fsMap map[string]string) (types.Config, error) {
 	if err := Check2_3(cfg, fsMap); err != nil {
 		return types.Config{}, err
 	}
+
+	files := translateFiles(cfg.Storage.Files, fsMap)
+	files = append(files, translateNetworkd(cfg.Networkd.Units, fsMap)...)
+
 	res := types.Config{
 		// Ignition section
 		Ignition: types.Ignition{
@@ -168,7 +170,7 @@ func Translate(cfg old.Config, fsMap map[string]string) (types.Config, error) {
 			Disks:       translateDisks(cfg.Storage.Disks),
 			Raid:        translateRaid(cfg.Storage.Raid),
 			Filesystems: translateFilesystems(cfg.Storage.Filesystems, fsMap),
-			Files:       translateFiles(cfg.Storage.Files, fsMap),
+			Files:       files,
 			Directories: translateDirectories(cfg.Storage.Directories, fsMap),
 			Links:       translateLinks(cfg.Storage.Links, fsMap),
 		},
@@ -483,6 +485,53 @@ func translateFiles(files []old.File, m map[string]string) (ret []types.File) {
 		ret = append(ret, file)
 	}
 	return
+}
+
+func translateNetworkd(units []old.Networkdunit, m map[string]string) []types.File {
+	var ret []types.File
+
+	for _, u := range units {
+		if u.Contents != "" {
+			file := types.File{
+				Node: types.Node{
+					// 2.x files are overwrite by default
+					Overwrite: util.BoolP(true),
+				},
+				FileEmbedded1: types.FileEmbedded1{
+					// Ignition default file permission
+					Mode: util.IntP(int(0644)),
+				},
+			}
+			// path /etc/systemd/network is hardcoded in Ignition2.x codebase.
+			// TODO: customize this path at compilation time.
+			file.Node.Path = filepath.Join(m["root"], "/etc/systemd/network", u.Name)
+
+			// URL encoding unit content to follow 'data' format - we could use base64 also.
+			file.FileEmbedded1.Contents.Source = util.StrPStrict("data:," + url.QueryEscape(u.Contents))
+
+			ret = append(ret, file)
+		}
+
+		for _, d := range u.Dropins {
+			file := types.File{
+				Node: types.Node{
+					// 2.x files are overwrite by default
+					Overwrite: util.BoolP(true),
+				},
+				FileEmbedded1: types.FileEmbedded1{
+					// Ignition default file permission
+					Mode: util.IntP(int(0644)),
+				},
+			}
+
+			file.Node.Path = filepath.Join(m["root"], "/etc/systemd/network", string(u.Name)+".d", d.Name)
+			file.FileEmbedded1.Contents.Source = util.StrPStrict("data:," + url.QueryEscape(d.Contents))
+
+			ret = append(ret, file)
+		}
+	}
+
+	return ret
 }
 
 func translateLinks(links []old.Link, m map[string]string) (ret []types.Link) {

--- a/translate_test.go
+++ b/translate_test.go
@@ -460,6 +460,24 @@ var (
 				},
 			},
 		},
+		Networkd: types2_4.Networkd{
+			Units: []types2_4.Networkdunit{
+				{
+					Contents: "[Match]\nName=eth*\n\n[Network]\nBond=bond0",
+					Dropins: []types2_4.NetworkdDropin{
+						{
+							Contents: "[Match]\nName=bond0\n\n[Network]\nDHCP=true",
+							Name:     "dropin-1.conf",
+						},
+					},
+					Name: "00-eth.network",
+				},
+				{
+					Contents: "[Match]\nName=eth12\n\n[Network]\nBond=bond0",
+					Name:     "99-eth.network",
+				},
+			},
+		},
 		Storage: types2_4.Storage{
 			Disks: []types2_4.Disk{
 				{
@@ -1465,6 +1483,42 @@ var (
 						Mode: util.IntP(420),
 						Contents: types3_1.Resource{
 							Source: util.StrPStrict(""),
+						},
+					},
+				},
+				{
+					Node: types3_1.Node{
+						Path:      "/etc/systemd/network/00-eth.network",
+						Overwrite: util.BoolPStrict(true),
+					},
+					FileEmbedded1: types3_1.FileEmbedded1{
+						Mode: util.IntP(420),
+						Contents: types3_1.Resource{
+							Source: util.StrPStrict("data:,%5BMatch%5D%0AName%3Deth%2A%0A%0A%5BNetwork%5D%0ABond%3Dbond0"),
+						},
+					},
+				},
+				{
+					Node: types3_1.Node{
+						Path:      "/etc/systemd/network/00-eth.network.d/dropin-1.conf",
+						Overwrite: util.BoolPStrict(true),
+					},
+					FileEmbedded1: types3_1.FileEmbedded1{
+						Mode: util.IntP(420),
+						Contents: types3_1.Resource{
+							Source: util.StrPStrict("data:,%5BMatch%5D%0AName%3Dbond0%0A%0A%5BNetwork%5D%0ADHCP%3Dtrue"),
+						},
+					},
+				},
+				{
+					Node: types3_1.Node{
+						Path:      "/etc/systemd/network/99-eth.network",
+						Overwrite: util.BoolPStrict(true),
+					},
+					FileEmbedded1: types3_1.FileEmbedded1{
+						Mode: util.IntP(420),
+						Contents: types3_1.Resource{
+							Source: util.StrPStrict("data:,%5BMatch%5D%0AName%3Deth12%0A%0A%5BNetwork%5D%0ABond%3Dbond0"),
 						},
 					},
 				},

--- a/util/util.go
+++ b/util/util.go
@@ -15,7 +15,6 @@
 package util
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -23,9 +22,6 @@ import (
 )
 
 // Error definitions
-
-// UsesNetworkdError is the error for including networkd configs
-var UsesNetworkdError = errors.New("config includes deprecated networkd section - use Files instead")
 
 // NoFilesystemError type for when a filesystem is referenced in a config but there's no mapping to where
 // it should be mounted (i.e. `path` in v3+ configs)


### PR DESCRIPTION
In this PR, we convert this config:
```json
{
  "ignition": {
    "version": "2.3.0"
  },
  "networkd": {
    "units": [
      {
        "name": "00-eth.network",
        "dropins": [
          {
            "name": "my-conf.conf",
            "contents": "[Match]\nName=eth*\n\n[Network]\nBond=bond0"
          }
        ],
        "contents": "[NetDev]\nName=bond0\nKind=bond"
      }
    ]
  }
}
```

to this config:
```json
{
  "ignition": {
    "version": "3.1.0"
  },
  "storage": {
    "files": [
      {
        "overwrite": true,
        "path": "/etc/systemd/network/00-eth.network",
        "contents": {
          "source": "data:,%5BNetDev%5D%0AName%3Dbond0%0AKind%3Dbond"
        },
        "mode": 420
      },
      {
        "overwrite": true,
        "path": "/etc/systemd/network/00-eth.network.d/my-conf.conf",
        "contents": {
          "source": "data:,%5BMatch%5D%0AName%3Deth%2A%0A%0A%5BNetwork%5D%0ABond%3Dbond0"
        },
        "mode": 420
      }
    ]
  }
}
```
## How to use

Locally:
```
go build ./internal/main.go
./main < config.json | jq
```

## Testing done

About to add some network ignition tests and to kick-off a CI.

## Note for reviewers
  * not sure about the URL encoded format, it seems pretty standard for inline ignition content
  * can be upstreamed to coreos/ign-converter
  * related to: https://github.com/flatcar-linux/Flatcar/issues/741