### PR TITLE
translate/networkd: use path escape to encode content

### DIFF
--- a/translate/v23tov30/v23tov30.go
+++ b/translate/v23tov30/v23tov30.go
@@ -507,7 +507,7 @@ func translateNetworkd(units []old.Networkdunit, m map[string]string) []types.Fi
 			file.Node.Path = filepath.Join(m["root"], "/etc/systemd/network", u.Name)
 
 			// URL encoding unit content to follow 'data' format - we could use base64 also.
-			file.FileEmbedded1.Contents.Source = util.StrPStrict("data:," + url.QueryEscape(u.Contents))
+			file.FileEmbedded1.Contents.Source = util.StrPStrict("data:," + url.PathEscape(u.Contents))
 
 			ret = append(ret, file)
 		}
@@ -525,7 +525,7 @@ func translateNetworkd(units []old.Networkdunit, m map[string]string) []types.Fi
 			}
 
 			file.Node.Path = filepath.Join(m["root"], "/etc/systemd/network", string(u.Name)+".d", d.Name)
-			file.FileEmbedded1.Contents.Source = util.StrPStrict("data:," + url.QueryEscape(d.Contents))
+			file.FileEmbedded1.Contents.Source = util.StrPStrict("data:," + url.PathEscape(d.Contents))
 
 			ret = append(ret, file)
 		}

--- a/translate/v24tov31/v24tov31.go
+++ b/translate/v24tov31/v24tov31.go
@@ -534,7 +534,7 @@ func translateNetworkd(units []old.Networkdunit, m map[string]string) []types.Fi
 			file.Node.Path = filepath.Join(m["root"], "/etc/systemd/network", u.Name)
 
 			// URL encoding unit content to follow 'data' format - we could use base64 also.
-			file.FileEmbedded1.Contents.Source = util.StrPStrict("data:," + url.QueryEscape(u.Contents))
+			file.FileEmbedded1.Contents.Source = util.StrPStrict("data:," + url.PathEscape(u.Contents))
 
 			ret = append(ret, file)
 		}
@@ -552,7 +552,7 @@ func translateNetworkd(units []old.Networkdunit, m map[string]string) []types.Fi
 			}
 
 			file.Node.Path = filepath.Join(m["root"], "/etc/systemd/network", string(u.Name)+".d", d.Name)
-			file.FileEmbedded1.Contents.Source = util.StrPStrict("data:," + url.QueryEscape(d.Contents))
+			file.FileEmbedded1.Contents.Source = util.StrPStrict("data:," + url.PathEscape(d.Contents))
 
 			ret = append(ret, file)
 		}

--- a/translate_test.go
+++ b/translate_test.go
@@ -463,7 +463,7 @@ var (
 		Networkd: types2_4.Networkd{
 			Units: []types2_4.Networkdunit{
 				{
-					Contents: "[Match]\nName=eth*\n\n[Network]\nBond=bond0",
+					Contents: "[Match]\nType=!vlan bond bridge\nName=eth*\n\n[Network]\nBond=bond0",
 					Dropins: []types2_4.NetworkdDropin{
 						{
 							Contents: "[Match]\nName=bond0\n\n[Network]\nDHCP=true",
@@ -1494,7 +1494,7 @@ var (
 					FileEmbedded1: types3_1.FileEmbedded1{
 						Mode: util.IntP(420),
 						Contents: types3_1.Resource{
-							Source: util.StrPStrict("data:,%5BMatch%5D%0AName%3Deth%2A%0A%0A%5BNetwork%5D%0ABond%3Dbond0"),
+							Source: util.StrPStrict("data:,%5BMatch%5D%0AType=%21vlan%20bond%20bridge%0AName=eth%2A%0A%0A%5BNetwork%5D%0ABond=bond0"),
 						},
 					},
 				},
@@ -1506,7 +1506,7 @@ var (
 					FileEmbedded1: types3_1.FileEmbedded1{
 						Mode: util.IntP(420),
 						Contents: types3_1.Resource{
-							Source: util.StrPStrict("data:,%5BMatch%5D%0AName%3Dbond0%0A%0A%5BNetwork%5D%0ADHCP%3Dtrue"),
+							Source: util.StrPStrict("data:,%5BMatch%5D%0AName=bond0%0A%0A%5BNetwork%5D%0ADHCP=true"),
 						},
 					},
 				},
@@ -1518,7 +1518,7 @@ var (
 					FileEmbedded1: types3_1.FileEmbedded1{
 						Mode: util.IntP(420),
 						Contents: types3_1.Resource{
-							Source: util.StrPStrict("data:,%5BMatch%5D%0AName%3Deth12%0A%0A%5BNetwork%5D%0ABond%3Dbond0"),
+							Source: util.StrPStrict("data:,%5BMatch%5D%0AName=eth12%0A%0A%5BNetwork%5D%0ABond=bond0"),
 						},
 					},
 				},


### PR DESCRIPTION
Ignition relies on dataurl which seems to unescape content from path and
not from the query.

it's not an issue except for space character which is encoded as "+" in
the query while it's encoded as "%20" in the path.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>
